### PR TITLE
Add navigation menu and contact pages

### DIFF
--- a/contact-form.html
+++ b/contact-form.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="ca">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Formulari de contacte - Projecte Sonda Estratosfèrica</title>
+    <!-- Tailwind CSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- Google Fonts: Inter -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #f0f4f8;
+        }
+        .phase-card {
+            background-color: white;
+            border-radius: 1rem;
+            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+        }
+    </style>
+</head>
+<body class="text-gray-800">
+    <div class="min-h-screen">
+        <nav class="bg-white shadow">
+            <div class="max-w-6xl mx-auto px-4 py-3 flex justify-end space-x-4">
+                <a href="contact-form.html" class="text-blue-600 hover:underline">Formulari de contacte</a>
+                <a href="contact.html" class="text-blue-600 hover:underline">Contacte</a>
+            </div>
+        </nav>
+        <main class="max-w-6xl mx-auto p-4 md:p-8">
+            <section class="mb-12">
+                <div class="phase-card p-6 md:p-8">
+                    <h2 class="text-3xl font-bold text-blue-900 mb-4">Formulari de contacte</h2>
+                    <form class="space-y-4">
+                        <input type="text" placeholder="Nom" class="w-full border border-gray-300 p-2 rounded" />
+                        <input type="email" placeholder="Correu electrònic" class="w-full border border-gray-300 p-2 rounded" />
+                        <textarea placeholder="Missatge" class="w-full border border-gray-300 p-2 rounded h-32"></textarea>
+                        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Envia</button>
+                    </form>
+                </div>
+            </section>
+        </main>
+        <footer class="bg-gray-800 text-white text-center p-6 mt-12">
+            <p>&copy; 2025 Projecte de Tecnologia. Tots els drets reservats.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="ca">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Contacte - Projecte Sonda Estratosfèrica</title>
+    <!-- Tailwind CSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- Google Fonts: Inter -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #f0f4f8;
+        }
+        .phase-card {
+            background-color: white;
+            border-radius: 1rem;
+            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+        }
+    </style>
+</head>
+<body class="text-gray-800">
+    <div class="min-h-screen">
+        <nav class="bg-white shadow">
+            <div class="max-w-6xl mx-auto px-4 py-3 flex justify-end space-x-4">
+                <a href="contact-form.html" class="text-blue-600 hover:underline">Formulari de contacte</a>
+                <a href="contact.html" class="text-blue-600 hover:underline">Contacte</a>
+            </div>
+        </nav>
+        <main class="max-w-6xl mx-auto p-4 md:p-8">
+            <section class="mb-12">
+                <div class="phase-card p-6 md:p-8">
+                    <h2 class="text-3xl font-bold text-blue-900 mb-4">Contacte</h2>
+                    <p class="text-gray-600">Si tens qualsevol dubte, escriu-nos a <a href="mailto:info@example.com" class="text-blue-600">info@example.com</a>.</p>
+                </div>
+            </section>
+        </main>
+        <footer class="bg-gray-800 text-white text-center p-6 mt-12">
+            <p>&copy; 2025 Projecte de Tecnologia. Tots els drets reservats.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -195,6 +195,12 @@
 
             return (
                 <div className="min-h-screen">
+                    <nav className="bg-white shadow">
+                        <div className="max-w-6xl mx-auto px-4 py-3 flex justify-end space-x-4">
+                            <a href="contact-form.html" className="text-blue-600 hover:underline">Formulari de contacte</a>
+                            <a href="contact.html" className="text-blue-600 hover:underline">Contacte</a>
+                        </div>
+                    </nav>
                     <header className="header-gradient text-white p-8 text-center rounded-b-3xl shadow-lg">
                         <div className="max-w-4xl mx-auto">
                             <h1 className="text-4xl md:text-5xl font-bold mb-2">Projecte Sonda Estratosfèrica</h1>
@@ -218,6 +224,7 @@
                                 </div>
                             </section>
                         ))}
+
                     </main>
 
                     <footer className="bg-gray-800 text-white text-center p-6 mt-12">


### PR DESCRIPTION
## Summary
- add top navigation with links to dedicated contact form and contact pages
- split contact form and contact information into separate subpages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aff71339d4832bb367ebb41be100b6